### PR TITLE
Syntax fix (elsif instead of elseif)

### DIFF
--- a/syntax/sieve.vim
+++ b/syntax/sieve.vim
@@ -25,7 +25,7 @@ syn keyword sieveStatement	allof anyof exists
 syn keyword sieveIdentifier	header address envelope 
 syn keyword sieveStatement	keep discard redirect reject
 syn keyword sieveStatement	require stop
-syn keyword sieveConditional	if elseif else frontis
+syn keyword sieveConditional	if elsif else frontis
 
 " pattern matching for comments
 syn match   sieveComment	"^\ *\#.*$"


### PR DESCRIPTION
The short form for `else if` is `elsif` and not `elseif` (confirmed in the  [rfc](https://tools.ietf.org/html/rfc5228#section-3.1))
